### PR TITLE
Add coupon & topping features

### DIFF
--- a/client/TinTinMobile/app/(admin)/coupon/index.tsx
+++ b/client/TinTinMobile/app/(admin)/coupon/index.tsx
@@ -1,11 +1,54 @@
-import { View, Text } from "react-native"
+import { useEffect, useState } from "react";
+import { View, FlatList, StyleSheet } from "react-native";
+import { router } from "expo-router";
+import HeaderList from "@/components/HeaderList";
+import ItemCoupon from "@/components/ItemCoupon";
+import EmptyState from "@/components/EmptyState";
+import { getCoupons } from "@/config/api";
+import { ICoupon } from "@/types/backend";
+import { COLORS } from "@/util/constant";
 
 const CouponScreen = () => {
-    return (
-        <View>
-            <Text>Coupon</Text>
-        </View>
-    )
-}   
+  const [coupons, setCoupons] = useState<ICoupon[]>([]);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchData = async () => {
+    const res = await getCoupons();
+    if (res.data) {
+      setCoupons(res.data);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await fetchData();
+    setRefreshing(false);
+  };
+
+  return (
+    <View style={styles.container}>
+      <HeaderList title="Coupons" backPress={() => router.back()} showAdd={false} />
+      <FlatList
+        data={coupons}
+        keyExtractor={(item) => String(item.id)}
+        renderItem={({ item }) => <ItemCoupon coupon={item} />}
+        refreshing={refreshing}
+        onRefresh={onRefresh}
+        ListEmptyComponent={<EmptyState title="No coupons" description="" />}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: COLORS.BACKGROUND,
+  },
+});
 
 export default CouponScreen;

--- a/client/TinTinMobile/app/(admin)/menu/index.tsx
+++ b/client/TinTinMobile/app/(admin)/menu/index.tsx
@@ -1,11 +1,54 @@
-import { View, Text } from "react-native";
+import { useEffect, useState } from "react";
+import { View, FlatList, StyleSheet } from "react-native";
+import { router } from "expo-router";
+import HeaderList from "@/components/HeaderList";
+import ItemTopping from "@/components/ItemTopping";
+import EmptyState from "@/components/EmptyState";
+import { getToppings } from "@/config/api";
+import { ITopping } from "@/types/backend";
+import { COLORS } from "@/util/constant";
 
 const MenuScreen = () => {
-    return (
-        <View>
-            <Text>Menu</Text>
-        </View>
-    )
-}   
+  const [toppings, setToppings] = useState<ITopping[]>([]);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchData = async () => {
+    const res = await getToppings();
+    if (res.data) {
+      setToppings(res.data);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await fetchData();
+    setRefreshing(false);
+  };
+
+  return (
+    <View style={styles.container}>
+      <HeaderList title="Toppings" backPress={() => router.back()} showAdd={false} />
+      <FlatList
+        data={toppings}
+        keyExtractor={(item) => String(item.id)}
+        renderItem={({ item }) => <ItemTopping topping={item} />}
+        refreshing={refreshing}
+        onRefresh={onRefresh}
+        ListEmptyComponent={<EmptyState title="No toppings" description="" />}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: COLORS.BACKGROUND,
+  },
+});
 
 export default MenuScreen;

--- a/client/TinTinMobile/components/ItemCoupon.tsx
+++ b/client/TinTinMobile/components/ItemCoupon.tsx
@@ -1,0 +1,69 @@
+import { ICoupon } from "@/types/backend";
+import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
+import AntDesign from '@expo/vector-icons/AntDesign';
+import { COLORS } from "@/util/constant";
+
+interface ItemCouponProps {
+  coupon: ICoupon;
+  onEdit?: () => void;
+  onDelete?: () => void;
+}
+
+const ItemCoupon = ({ coupon, onEdit, onDelete }: ItemCouponProps) => {
+  return (
+    <View style={styles.container}>
+      <View style={{ flex: 1 }}>
+        <Text style={styles.title}>{coupon.code}</Text>
+        {coupon.description && (
+          <Text style={styles.description}>{coupon.description}</Text>
+        )}
+        <Text style={styles.description}>
+          {coupon.discountType === 'PERCENT'
+            ? `${coupon.discountValue}%`
+            : `- ${coupon.discountValue}`}
+        </Text>
+      </View>
+      <View style={styles.buttonContainer}>
+        {onEdit && (
+          <TouchableOpacity onPress={onEdit}>
+            <AntDesign name="edit" size={24} color={COLORS.ITEM_TEXT} />
+          </TouchableOpacity>
+        )}
+        {onDelete && (
+          <TouchableOpacity onPress={onDelete}>
+            <AntDesign name="delete" size={24} color={COLORS.ITEM_TEXT} />
+          </TouchableOpacity>
+        )}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: 1,
+    borderColor: COLORS.ITEM_BORDER,
+    padding: 16,
+    borderRadius: 12,
+    marginVertical: 8,
+    backgroundColor: COLORS.ITEM_BACKGROUND,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: COLORS.ITEM_TEXT,
+  },
+  description: {
+    fontSize: 12,
+    color: COLORS.ITEM_TEXT,
+  },
+  buttonContainer: {
+    flexDirection: 'column',
+    gap: 10,
+  },
+});
+
+export default ItemCoupon;

--- a/client/TinTinMobile/components/ItemTopping.tsx
+++ b/client/TinTinMobile/components/ItemTopping.tsx
@@ -1,0 +1,82 @@
+import { ITopping } from "@/types/backend";
+import { View, Text, StyleSheet, Image, TouchableOpacity } from "react-native";
+import AntDesign from '@expo/vector-icons/AntDesign';
+import { COLORS } from "@/util/constant";
+
+const imagePlaceholder = require("@/assets/images/setting/avatar_default.jpg");
+
+interface ItemToppingProps {
+  topping: ITopping;
+  onEdit?: () => void;
+  onDelete?: () => void;
+}
+
+const ItemTopping = ({ topping, onEdit, onDelete }: ItemToppingProps) => {
+  return (
+    <View style={styles.container}>
+      <View style={styles.infoContainer}>
+        <Image
+          source={topping.image ? { uri: topping.image } : imagePlaceholder}
+          style={styles.image}
+        />
+        <View style={{ marginLeft: 10 }}>
+          <Text style={styles.title}>{topping.name}</Text>
+          <Text style={styles.description}>{topping.price}</Text>
+        </View>
+      </View>
+      <View style={styles.buttonContainer}>
+        {onEdit && (
+          <TouchableOpacity onPress={onEdit}>
+            <AntDesign name="edit" size={24} color={COLORS.ITEM_TEXT} />
+          </TouchableOpacity>
+        )}
+        {onDelete && (
+          <TouchableOpacity onPress={onDelete}>
+            <AntDesign name="delete" size={24} color={COLORS.ITEM_TEXT} />
+          </TouchableOpacity>
+        )}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: 1,
+    borderColor: COLORS.ITEM_BORDER,
+    padding: 16,
+    borderRadius: 12,
+    marginVertical: 8,
+    backgroundColor: COLORS.ITEM_BACKGROUND,
+  },
+  infoContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+  },
+  image: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    borderWidth: 1,
+    borderColor: COLORS.ITEM_BORDER,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: COLORS.ITEM_TEXT,
+  },
+  description: {
+    fontSize: 12,
+    color: COLORS.ITEM_TEXT,
+  },
+  buttonContainer: {
+    flexDirection: 'column',
+    gap: 10,
+  },
+});
+
+export default ItemTopping;

--- a/client/TinTinMobile/config/api.ts
+++ b/client/TinTinMobile/config/api.ts
@@ -1,4 +1,4 @@
-import { IAccount, IAddressUser, IBackendRes, IFile, IGetAccount, IModelPaginate, IRole, IUser } from "@/types/backend"
+import { IAccount, IAddressUser, IBackendRes, IFile, IGetAccount, IModelPaginate, IRole, IUser, ICoupon, ITopping } from "@/types/backend"
 import axios from "./axios-customize"
 
 /**
@@ -114,4 +114,50 @@ export const updateAddress = (address: IAddressUser) => {
 
 export const deleteAddress = (id: string) => {
     return axios.delete<IBackendRes<void>>(`/api/v1/addresses-user/${id}`)
+}
+
+/**
+ * Module Coupon
+ */
+export const getCoupons = () => {
+    return axios.get<IBackendRes<ICoupon[]>>('/api/v1/coupons');
+}
+
+export const getCouponById = (id: string) => {
+    return axios.get<IBackendRes<ICoupon>>(`/api/v1/coupons/${id}`);
+}
+
+export const createCoupon = (coupon: ICoupon) => {
+    return axios.post<IBackendRes<ICoupon>>('/api/v1/coupons', coupon);
+}
+
+export const updateCoupon = (id: string, coupon: ICoupon) => {
+    return axios.put<IBackendRes<ICoupon>>(`/api/v1/coupons/${id}`, coupon);
+}
+
+export const deleteCoupon = (id: string) => {
+    return axios.delete<IBackendRes<ICoupon>>(`/api/v1/coupons/${id}`);
+}
+
+/**
+ * Module Topping
+ */
+export const getToppings = () => {
+    return axios.get<IBackendRes<ITopping[]>>('/api/v1/toppings');
+}
+
+export const getToppingById = (id: string) => {
+    return axios.get<IBackendRes<ITopping>>(`/api/v1/toppings/${id}`);
+}
+
+export const createTopping = (topping: ITopping) => {
+    return axios.post<IBackendRes<ITopping>>('/api/v1/toppings', topping);
+}
+
+export const updateTopping = (topping: ITopping) => {
+    return axios.put<IBackendRes<ITopping>>('/api/v1/toppings', topping);
+}
+
+export const deleteTopping = (id: string) => {
+    return axios.delete<IBackendRes<void>>(`/api/v1/toppings/${id}`);
 }

--- a/client/TinTinMobile/types/backend.d.ts
+++ b/client/TinTinMobile/types/backend.d.ts
@@ -108,3 +108,35 @@ export interface IAddressUser {
     id: string
   };
 }
+
+export interface ICoupon {
+  id?: number;
+  code: string;
+  description?: string;
+  image?: string;
+  discountType: "PERCENT" | "AMOUNT";
+  discountValue: number;
+  maxDiscount?: number;
+  minOrderValue?: number;
+  quantity: number;
+  startDate?: string;
+  endDate?: string;
+  isActive?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+  createdBy?: string;
+  updatedBy?: string;
+}
+
+export interface ITopping {
+  id?: number;
+  name: string;
+  image?: string;
+  description?: string;
+  price: number;
+  status?: "INACTIVE" | "ACTIVE" | "DELETED";
+  createdAt?: string;
+  updatedAt?: string;
+  createdBy?: string;
+  updatedBy?: string;
+}


### PR DESCRIPTION
## Summary
- define `ICoupon` and `ITopping` models
- implement API helpers for coupon and topping modules
- create `ItemCoupon` and `ItemTopping` components
- display coupon list on admin coupon screen
- display topping list on admin menu screen

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684592a9f7708333ae58dae39288d8fc