### PR TITLE
Integrate mobile user pages with API

### DIFF
--- a/client/TinTinMobile/app/(user)/favorites/index.tsx
+++ b/client/TinTinMobile/app/(user)/favorites/index.tsx
@@ -1,10 +1,16 @@
-import React from 'react';
+import React, { useEffect, useCallback, useState } from 'react';
 import { View, Text, ScrollView, Image, StyleSheet, TouchableOpacity, FlatList } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { COLORS } from '@/util/constant';
 import AntDesign from '@expo/vector-icons/AntDesign';
 import { useFavorites } from '@/context/FavoritesContext';
-import { allProducts, toppings } from '@/app/(user)/home';
+import { useAppContext } from '@/context/AppContext';
+import { callGetProducts, callGetToppings, callGetProductFavoritesOfUser, callGetToppingFavoritesOfUser } from '@/config/api';
+import { useFocusEffect } from 'expo-router';
+
+const IPV4 = process.env.EXPO_PUBLIC_IPV4;
+const PORT = process.env.EXPO_PUBLIC_PORT;
+const image_url_base = `http://${IPV4}:${PORT}/storage`;
 import { router } from 'expo-router';
 
 interface Topping {
@@ -16,24 +22,74 @@ interface Topping {
 }
 
 export default function FavoritesScreen() {
-  const { favorites, favoriteToppings, toggleFavorite, toggleFavoriteTopping } = useFavorites();
+  const [products, setProducts] = useState<any[]>([]);
+  const [toppingList, setToppingList] = useState<any[]>([]);
+  const { user } = useAppContext();
+  const {
+    favorites,
+    favoriteToppings,
+    toggleFavorite,
+    toggleFavoriteTopping,
+    setFavoritesList,
+    setFavoriteToppingsList,
+  } = useFavorites();
 
-  // TODO: Gọi API lấy danh sách sản phẩm yêu thích
-  // const fetchFavoriteProducts = async () => {
-  //   const response = await callGetFavoriteProducts();
-  //   setFavoriteProducts(response.data);
-  // };
+  useFocusEffect(
+    useCallback(() => {
+      const fetchData = async () => {
+        try {
+          const [prodRes, topRes] = await Promise.all([
+            callGetProducts({}),
+            callGetToppings({}),
+          ]);
 
-  // TODO: Gọi API lấy danh sách topping yêu thích
-  // const fetchFavoriteToppings = async () => {
-  //   const response = await callGetFavoriteToppings();
-  //   setFavoriteToppings(response.data);
-  // };
+          if (prodRes.data) {
+            const mapped = prodRes.data.map((p: any) => ({
+              id: Number(p.id),
+              name: p.name,
+              subtitle: p.description || '',
+              image: { uri: `${image_url_base}/product/${p.image}` },
+              price: '0',
+            }));
+            setProducts(mapped);
+          }
 
-  const favoriteProductsData = allProducts.filter(product => favorites.includes(product.id));
-  const favoriteToppingsData = toppings.filter((topping: Topping) => favoriteToppings.includes(topping.id));
+          if (topRes.data) {
+            const mappedT = topRes.data.map((t: any) => ({
+              id: Number(t.id),
+              name: t.name,
+              subtitle: t.description || '',
+              image: { uri: `${image_url_base}/topping/${t.image}` },
+              price: t.price?.toString() || '0',
+            }));
+            setToppingList(mappedT);
+          }
 
-  const renderProduct = ({ item }: { item: typeof allProducts[0] }) => (
+          if (user?.user.id) {
+            const [favProdRes, favTopRes] = await Promise.all([
+              callGetProductFavoritesOfUser(user.user.id),
+              callGetToppingFavoritesOfUser(user.user.id),
+            ]);
+
+            if (favProdRes.data) {
+              setFavoritesList(favProdRes.data.map((f: any) => Number(f.product.id)));
+            }
+            if (favTopRes.data) {
+              setFavoriteToppingsList(favTopRes.data.map((f: any) => Number(f.topping.id)));
+            }
+          }
+        } catch (error) {
+          console.error('Error fetching favorites data', error);
+        }
+      };
+      fetchData();
+    }, [user?.user.id])
+  );
+
+  const favoriteProductsData = products.filter(product => favorites.includes(product.id));
+  const favoriteToppingsData = toppingList.filter((topping: Topping) => favoriteToppings.includes(topping.id));
+
+  const renderProduct = ({ item }: { item: any }) => (
     <TouchableOpacity style={styles.productCard}>
       <Image source={item.image} style={styles.productImage} />
       <TouchableOpacity 
@@ -68,7 +124,7 @@ export default function FavoritesScreen() {
     </TouchableOpacity>
   );
 
-  const renderTopping = ({ item }: { item: typeof toppings[0] }) => (
+  const renderTopping = ({ item }: { item: any }) => (
     <TouchableOpacity style={styles.toppingCard}>
       <Image source={item.image} style={styles.toppingImage} />
       <TouchableOpacity 

--- a/client/TinTinMobile/app/(user)/orders/index.tsx
+++ b/client/TinTinMobile/app/(user)/orders/index.tsx
@@ -3,8 +3,10 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { COLORS } from '@/util/constant';
 import AntDesign from '@expo/vector-icons/AntDesign';
 import { router, useFocusEffect } from 'expo-router';
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useOrders } from '@/context/OrderContext';
+import { useAppContext } from '@/context/AppContext';
+import { callGetOrders } from '@/config/api';
 
 interface Order {
   id: string;
@@ -24,20 +26,34 @@ interface Order {
 }
 
 export default function OrdersScreen() {
-  const { orders, updateOrderStatus } = useOrders();
+  const { orders, updateOrderStatus, setOrdersList } = useOrders();
+  const { user } = useAppContext();
 
   console.log('Current orders in OrdersScreen:', orders);
 
   // Refresh orders when screen is focused
   useFocusEffect(
     useCallback(() => {
-      // TODO: Gọi API lấy danh sách đơn hàng của user
-      // const fetchOrders = async () => {
-      //   const response = await callGetOrders();
-      //   setOrders(response.data);
-      // };
-      // fetchOrders();
-    }, [])
+      const fetchOrders = async () => {
+        if (!user?.user.id) return;
+        try {
+          const res = await callGetOrders({ filter: `user.id:${user.user.id}` });
+          if (res.data) {
+            const mapped = res.data.map((o: any) => ({
+              id: o.id,
+              date: o.createdAt || '',
+              status: o.status,
+              items: o.orderDetails || [],
+              total: o.finalPrice?.toString() || '0',
+            }));
+            setOrdersList(mapped);
+          }
+        } catch (error) {
+          console.error('Error fetching orders', error);
+        }
+      };
+      fetchOrders();
+    }, [user?.user.id])
   );
 
   const handlePaymentPress = (orderId: string) => {

--- a/client/TinTinMobile/context/FavoritesContext.tsx
+++ b/client/TinTinMobile/context/FavoritesContext.tsx
@@ -5,6 +5,8 @@ interface FavoritesContextType {
   favoriteToppings: number[];
   toggleFavorite: (id: number) => void;
   toggleFavoriteTopping: (id: number) => void;
+  setFavoritesList: (ids: number[]) => void;
+  setFavoriteToppingsList: (ids: number[]) => void;
 }
 
 const FavoritesContext = createContext<FavoritesContextType | undefined>(undefined);
@@ -20,13 +22,30 @@ export const FavoritesProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const toggleFavoriteTopping = (id: number) => {
-    setFavoriteToppings(prev => 
+    setFavoriteToppings(prev =>
       prev.includes(id) ? prev.filter(item => item !== id) : [...prev, id]
     );
   };
 
+  const setFavoritesList = (ids: number[]) => {
+    setFavorites(ids);
+  };
+
+  const setFavoriteToppingsList = (ids: number[]) => {
+    setFavoriteToppings(ids);
+  };
+
   return (
-    <FavoritesContext.Provider value={{ favorites, favoriteToppings, toggleFavorite, toggleFavoriteTopping }}>
+    <FavoritesContext.Provider
+      value={{
+        favorites,
+        favoriteToppings,
+        toggleFavorite,
+        toggleFavoriteTopping,
+        setFavoritesList,
+        setFavoriteToppingsList,
+      }}
+    >
       {children}
     </FavoritesContext.Provider>
   );

--- a/client/TinTinMobile/context/OrderContext.tsx
+++ b/client/TinTinMobile/context/OrderContext.tsx
@@ -23,6 +23,7 @@ interface OrderContextType {
   orders: Order[];
   addOrder: (order: Order) => void;
   updateOrderStatus: (orderId: string, newStatus: string) => void;
+  setOrdersList: (orders: Order[]) => void;
 }
 
 const OrderContext = createContext<OrderContextType | undefined>(undefined);
@@ -42,8 +43,12 @@ export const OrderProvider = ({ children }: { children: ReactNode }) => {
     );
   };
 
+  const setOrdersList = (orders: Order[]) => {
+    setOrders(orders);
+  };
+
   return (
-    <OrderContext.Provider value={{ orders, addOrder, updateOrderStatus }}>
+    <OrderContext.Provider value={{ orders, addOrder, updateOrderStatus, setOrdersList }}>
       {children}
     </OrderContext.Provider>
   );


### PR DESCRIPTION
## Summary
- extend favorites and orders contexts to support initial data loading
- load products, toppings and favorites via API on home screen
- fetch and display favorite items using server data
- retrieve user orders from the server on focus

## Testing
- `npm install --ignore-scripts`
- `npm run lint` *(fails: react/no-unescaped-entities errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6845b17e0e8883339eef595ff6b6c7b6