### PR TITLE
Add permission-based security

### DIFF
--- a/server/TinTin/TinTin/src/main/java/com/example/TinTin/config/SecurityConfiguration.java
+++ b/server/TinTin/TinTin/src/main/java/com/example/TinTin/config/SecurityConfiguration.java
@@ -19,11 +19,13 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtGra
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfiguration {
 
     @Value("${jwt.secret}")
@@ -44,7 +46,7 @@ public class SecurityConfiguration {
                 )
                 .oauth2ResourceServer(oauth2 -> oauth2
                         .authenticationEntryPoint(customAuthenticationEntryPoint)
-                        .jwt(Customizer.withDefaults())
+                        .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter()))
 
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));

--- a/server/TinTin/TinTin/src/main/java/com/example/TinTin/config/UserDetailCustom.java
+++ b/server/TinTin/TinTin/src/main/java/com/example/TinTin/config/UserDetailCustom.java
@@ -1,5 +1,6 @@
 package com.example.TinTin.config;
 
+import com.example.TinTin.domain.Permission;
 import com.example.TinTin.service.UserService;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
@@ -8,7 +9,8 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Component("userDetailsService")
@@ -23,10 +25,19 @@ public class UserDetailCustom implements UserDetailsService {
         if(user == null){
             throw new UsernameNotFoundException("Username/password không hợp lệ");
         }
+        List<SimpleGrantedAuthority> authorities = new ArrayList<>();
+        if (user.getRole() != null) {
+            authorities.add(new SimpleGrantedAuthority(user.getRole().getName()));
+            if (user.getRole().getPermissions() != null) {
+                for (Permission permission : user.getRole().getPermissions()) {
+                    authorities.add(new SimpleGrantedAuthority(permission.getName()));
+                }
+            }
+        }
         return new User(
                 user.getEmail(),
                 user.getPassword(),
-                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+                authorities
         );
     }
 }

--- a/server/TinTin/TinTin/src/main/java/com/example/TinTin/controller/CategoryController.java
+++ b/server/TinTin/TinTin/src/main/java/com/example/TinTin/controller/CategoryController.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -23,6 +24,7 @@ public class CategoryController {
 
     @PostMapping("/categories")
     @ApiMessage("Create new category")
+    @PreAuthorize("hasAuthority('CATEGORY_CREATE')")
     public ResponseEntity<Category> createCategory(@Valid @RequestBody Category category){
         return ResponseEntity.status(HttpStatus.CREATED).body(this.categoryService.createCategory(category));
 
@@ -30,12 +32,14 @@ public class CategoryController {
 
     @GetMapping("/categories")
     @ApiMessage("Get list categories")
+    @PreAuthorize("hasAuthority('CATEGORY_READ')")
     public ResponseEntity<List<Category>> getAllCategory(@Filter Specification<Category> spec){
         return ResponseEntity.ok().body(this.categoryService.getListOfCategories(spec));
     }
 
     @DeleteMapping("/categories/{id}")
     @ApiMessage("Delete a category")
+    @PreAuthorize("hasAuthority('CATEGORY_DELETE')")
     public ResponseEntity<Void> deleteCategory(@PathVariable("id") Long id){
         this.categoryService.deleteCategory(id);
         return ResponseEntity.ok().body(null);
@@ -43,12 +47,14 @@ public class CategoryController {
 
     @PutMapping("/categories")
     @ApiMessage("Update a category")
+    @PreAuthorize("hasAuthority('CATEGORY_UPDATE')")
     public ResponseEntity<Category> updateCategory(@Valid @RequestBody Category category){
         return ResponseEntity.ok().body(this.categoryService.updateCategory(category));
     }
 
     @GetMapping("/categories/{id}")
     @ApiMessage("Get category by ID")
+    @PreAuthorize("hasAuthority('CATEGORY_READ')")
     public ResponseEntity<Category> getCategoryById(@PathVariable("id") Long id) {
         return ResponseEntity.ok().body(this.categoryService.getCategoryById(id));
     }

--- a/server/TinTin/TinTin/src/main/java/com/example/TinTin/controller/RoleController.java
+++ b/server/TinTin/TinTin/src/main/java/com/example/TinTin/controller/RoleController.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -26,18 +27,21 @@ public class RoleController {
 
     @PostMapping("/roles")
     @ApiMessage("Create new role")
+    @PreAuthorize("hasAuthority('ROLE_CREATE')")
     public ResponseEntity<Role> createRole(@Valid @RequestBody Role role) throws BadRequestException {
         return ResponseEntity.status(HttpStatus.CREATED).body(this.roleService.createRole(role));
     }
 
     @PutMapping("/roles")
     @ApiMessage("Update role")
+    @PreAuthorize("hasAuthority('ROLE_UPDATE')")
     public ResponseEntity<Role> updateRole(@Valid @RequestBody Role role) throws BadRequestException {
         return ResponseEntity.status(HttpStatus.OK).body(this.roleService.updateRole(role));
     }
 
     @GetMapping("/roles")
     @ApiMessage("Get roles with pagination")
+    @PreAuthorize("hasAuthority('ROLE_READ')")
     public ResponseEntity<ResultPaginationDTO<List<Role>>> getAllRole(
             @Filter Specification<Role> spec,
             Pageable pageable
@@ -51,6 +55,7 @@ public class RoleController {
 
     @DeleteMapping("/roles/{id}")
     @ApiMessage("Delete a role")
+    @PreAuthorize("hasAuthority('ROLE_DELETE')")
     public ResponseEntity<Void> deleteRole(@PathVariable long id){
         this.roleService.deleteRole(id);
         return ResponseEntity.ok().body(null);

--- a/server/TinTin/TinTin/src/main/java/com/example/TinTin/controller/UserController.java
+++ b/server/TinTin/TinTin/src/main/java/com/example/TinTin/controller/UserController.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -29,6 +30,7 @@ public class UserController {
 
     @PostMapping("/users")
     @ApiMessage("Creat a new user")
+    @PreAuthorize("hasAuthority('USER_CREATE')")
     public ResponseEntity<UserCreateDto> createUser(@Valid @RequestBody User user){
 
         return ResponseEntity.status(HttpStatus.CREATED).body(this.userService.handleCreateUser(user));
@@ -36,6 +38,7 @@ public class UserController {
 
     @GetMapping("/users")
     @ApiMessage("Fetch all users")
+    @PreAuthorize("hasAuthority('USER_READ')")
     public ResponseEntity<ResultPaginationDTO<List<UserResponseDto>>> getUsers(
             @Filter Specification<User> spec,
             Pageable pageable
@@ -48,12 +51,14 @@ public class UserController {
 
     @PutMapping("/users")
     @ApiMessage("update a user")
+    @PreAuthorize("hasAuthority('USER_UPDATE')")
     public ResponseEntity<UserUpdateDto> updateUser(@Valid @RequestBody User user){
         return ResponseEntity.status(HttpStatus.OK).body(this.userService.handleUpdateUser(user));
     }
 
     @DeleteMapping("/users/{id}")
     @ApiMessage("Delete a user")
+    @PreAuthorize("hasAuthority('USER_DELETE')")
     public ResponseEntity<Void> deleteUser(@PathVariable("id") long id){
         this.userService.deleteUser(id);
         return ResponseEntity.ok().body(null);
@@ -61,6 +66,7 @@ public class UserController {
 
     @GetMapping("/users/{id}")
     @ApiMessage("fetch user by id")
+    @PreAuthorize("hasAuthority('USER_READ')")
     public ResponseEntity<UserResponseDto> getUserById(@PathVariable("id") long id){
         return ResponseEntity.ok().body(this.userService.getUserById(id));
     }

--- a/server/TinTin/TinTin/src/main/java/com/example/TinTin/util/SecurityUtil.java
+++ b/server/TinTin/TinTin/src/main/java/com/example/TinTin/util/SecurityUtil.java
@@ -64,7 +64,7 @@ public class SecurityUtil {
     }
 
 
-    public String createAccessToken(String email, ResLoginDTO dto) {
+    public String createAccessToken(String email, ResLoginDTO dto, List<String> permissions) {
         ResLoginDTO.UserInsideToken userInsideToken = new ResLoginDTO.UserInsideToken();
         userInsideToken.setId(dto.getUser().getId());
         userInsideToken.setEmail(dto.getUser().getEmail());
@@ -72,9 +72,7 @@ public class SecurityUtil {
         Instant now = Instant.now();
         Instant validity = now.plus(this.accessTokenExpiration, ChronoUnit.SECONDS);
 
-        List<String> listAuthority = new ArrayList<String>();
-        listAuthority.add("ROLE_USER_CREATE");
-        listAuthority.add("ROLE_USER_UPDATE");
+        List<String> listAuthority = new ArrayList<>(permissions);
         // @formatter:off
         JwtClaimsSet claims = JwtClaimsSet.builder()
                 .issuedAt(now)


### PR DESCRIPTION
## Summary
- expand `UserDetailCustom` to include role permissions
- wire up `JwtAuthenticationConverter` and enable method security
- embed real permissions in JWT creation
- add authorization checks on controllers

## Testing
- `sh gradlew test --no-daemon` *(fails: Cannot find a Java installation matching 17)*

------
https://chatgpt.com/codex/tasks/task_e_6846b5e476b48333bda9dfcc2fbd2665