### PR TITLE
Add login history tracking and account lock

### DIFF
--- a/server/TinTin/TinTin/src/main/java/com/example/TinTin/controller/LoginHistoryController.java
+++ b/server/TinTin/TinTin/src/main/java/com/example/TinTin/controller/LoginHistoryController.java
@@ -1,0 +1,27 @@
+package com.example.TinTin.controller;
+
+import com.example.TinTin.domain.LoginHistory;
+import com.example.TinTin.service.LoginHistoryService;
+import com.example.TinTin.util.annotation.ApiMessage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class LoginHistoryController {
+    private final LoginHistoryService loginHistoryService;
+
+    public LoginHistoryController(LoginHistoryService loginHistoryService) {
+        this.loginHistoryService = loginHistoryService;
+    }
+
+    @GetMapping("/login-histories")
+    @ApiMessage("Get login history")
+    public ResponseEntity<Page<LoginHistory>> getHistory(Pageable pageable){
+        return ResponseEntity.ok(loginHistoryService.getHistory(pageable));
+    }
+}

--- a/server/TinTin/TinTin/src/main/java/com/example/TinTin/domain/LoginHistory.java
+++ b/server/TinTin/TinTin/src/main/java/com/example/TinTin/domain/LoginHistory.java
@@ -1,0 +1,38 @@
+package com.example.TinTin.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "login_history")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginHistory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String ip;
+
+    private Boolean success;
+
+    private String email;
+
+    private Instant createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @PrePersist
+    public void prePersist(){
+        this.createdAt = Instant.now();
+    }
+}

--- a/server/TinTin/TinTin/src/main/java/com/example/TinTin/domain/User.java
+++ b/server/TinTin/TinTin/src/main/java/com/example/TinTin/domain/User.java
@@ -44,6 +44,9 @@ public class User {
 
     @Column(columnDefinition = "MEDIUMTEXT")
     private String refreshToken;
+
+    private Integer failedLoginAttempts;
+    private Boolean accountLocked;
     private Instant createdAt;
     private Instant updatedAt;
     private String createdBy;
@@ -73,11 +76,15 @@ public class User {
     public void preCreateUser(){
         this.createdAt = Instant.now();
         this.createdBy = SecurityUtil.getCurrentUserLogin().isPresent()?SecurityUtil.getCurrentUserLogin().get():"";
+        if(this.failedLoginAttempts == null) this.failedLoginAttempts = 0;
+        if(this.accountLocked == null) this.accountLocked = false;
     }
 
     @PreUpdate
     public void preUpdateUser(){
         this.updatedAt = Instant.now();
         this.updatedBy = SecurityUtil.getCurrentUserLogin().isPresent()?SecurityUtil.getCurrentUserLogin().get():"";
+        if(this.failedLoginAttempts == null) this.failedLoginAttempts = 0;
+        if(this.accountLocked == null) this.accountLocked = false;
     }
 }

--- a/server/TinTin/TinTin/src/main/java/com/example/TinTin/repository/LoginHistoryRepository.java
+++ b/server/TinTin/TinTin/src/main/java/com/example/TinTin/repository/LoginHistoryRepository.java
@@ -1,0 +1,9 @@
+package com.example.TinTin.repository;
+
+import com.example.TinTin.domain.LoginHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LoginHistoryRepository extends JpaRepository<LoginHistory, Long> {
+}

--- a/server/TinTin/TinTin/src/main/java/com/example/TinTin/service/LoginHistoryService.java
+++ b/server/TinTin/TinTin/src/main/java/com/example/TinTin/service/LoginHistoryService.java
@@ -1,0 +1,24 @@
+package com.example.TinTin.service;
+
+import com.example.TinTin.domain.LoginHistory;
+import com.example.TinTin.repository.LoginHistoryRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LoginHistoryService {
+    private final LoginHistoryRepository loginHistoryRepository;
+
+    public LoginHistoryService(LoginHistoryRepository loginHistoryRepository) {
+        this.loginHistoryRepository = loginHistoryRepository;
+    }
+
+    public LoginHistory save(LoginHistory history){
+        return loginHistoryRepository.save(history);
+    }
+
+    public Page<LoginHistory> getHistory(Pageable pageable){
+        return loginHistoryRepository.findAll(pageable);
+    }
+}

--- a/server/TinTin/TinTin/src/main/resources/application.properties
+++ b/server/TinTin/TinTin/src/main/resources/application.properties
@@ -7,7 +7,8 @@ spring.datasource.password=123456
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.show-sql:true
 
-# JWT Secret và th?i gian h?t h?n
+upload-file.base-uri=file:///D:/project/TinTin/upload/
+security.login.max-failed-attempts=5
 jwt.secret=qoAEABDke07+AVLepXB4aCMtsT0wMAqR5x2VFyldsnx6e75YQkJH2UcZKTjEyoNgG71SBCXfq5N6NVZxWOfsHQ== 
 jwt.access-token.expiration=86400
 jwt.refresh-token.expiration=100000


### PR DESCRIPTION
## Summary
- create LoginHistory entity, repository, service, and controller
- record login attempts in AuthController
- add failed attempt tracking and account lock in User and UserService
- expose `/login-histories` endpoint
- configure `security.login.max-failed-attempts` property

## Testing
- `./gradlew test` *(fails: cannot locate JDK 17)*

------
https://chatgpt.com/codex/tasks/task_e_6846b5f53bf48333bb076da575d50427